### PR TITLE
Fix signature error

### DIFF
--- a/src/thermint.jl
+++ b/src/thermint.jl
@@ -30,7 +30,7 @@ function ThermInt(schedule; n_samples::Int=2000, n_warmup::Int=500)
 end
 
 function ThermInt(rng::AbstractRNG; n_steps::Int, n_samples::Int=2000, n_warmup::Int=500)
-    return ThermInt(rng, ((1:n_steps) ./ n_steps) .^ 5, n_samples, n_warmup, rng)
+    return ThermInt(((1:n_steps) ./ n_steps) .^ 5, n_samples, n_warmup, rng)
 end
 
 function ThermInt(; n_steps::Int=30, n_samples::Int=2000, n_warmup::Int=500)

--- a/src/thermint.jl
+++ b/src/thermint.jl
@@ -30,7 +30,7 @@ function ThermInt(schedule; n_samples::Int=2000, n_warmup::Int=500)
 end
 
 function ThermInt(rng::AbstractRNG; n_steps::Int, n_samples::Int=2000, n_warmup::Int=500)
-    return ThermInt(((1:n_steps) ./ n_steps) .^ 5, n_samples, n_warmup, rng)
+    return ThermInt(rng, ((1:n_steps) ./ n_steps) .^ 5; n_samples=n_samples, n_warmup=n_warmup)
 end
 
 function ThermInt(; n_steps::Int=30, n_samples::Int=2000, n_warmup::Int=500)


### PR DESCRIPTION
One of the constructors for `ThermInt` erroneously passes `rng` twice.